### PR TITLE
Fix tsc errors after release of typescript 6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "lib": ["ES2021.String"],
     "module": "CommonJS",
+    "types": ["node", "jest"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Types node and jest need to be defined in ts config when using typescript 6